### PR TITLE
Allow swipe back for in-app safari

### DIFF
--- a/claw/ActiveSheet.swift
+++ b/claw/ActiveSheet.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ActiveSheet: Identifiable {
+enum ActiveSheet: Identifiable, Equatable {
     case share(URL)
     case safari(URL)
     case story(id:String)

--- a/claw/ContentView.swift
+++ b/claw/ContentView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import CoreData
 import Combine
+import BetterSafariView
 
 struct DidReselectKey: EnvironmentKey {
     static let defaultValue = PassthroughSubject<TabSelection, Never>().eraseToAnyPublisher()
@@ -124,7 +125,8 @@ struct ContentView: View {
                 Image(systemName: "gear")
                 Text("Settings")
             }).environmentObject(settings).environment(\.managedObjectContext, viewContext)
-        }.environment(\.didReselect, didReselect.eraseToAnyPublisher()).accentColor(settings.accentColor).font(Font(.body, sizeModifier: CGFloat(settings.textSizeModifier))).onOpenURL(perform: { url in
+        }.environment(\.didReselect, didReselect.eraseToAnyPublisher())
+        .onOpenURL(perform: { url in
             let _ = print(url)
             let openAction = {
                 if url.host == "open", let comps = URLComponents(url: url, resolvingAgainstBaseURL: false), let items = comps.queryItems, let item = items.first, item.name == "url", let itemValue = item.value, let lobsters_url = URL(string: itemValue), lobsters_url.host == "lobste.rs" {
@@ -159,7 +161,7 @@ struct ContentView: View {
                 openAction()
             }
         })
-        .sheet(item: self.observableSheet.bindingSheet, content: { item in
+        .sheet(item: self.$observableSheet.sheet, content: { item in
             switch item {
             case .story(let id):
                 EZPanel{
@@ -204,6 +206,8 @@ struct ContentView: View {
         .environment(\.managedObjectContext, viewContext)
         .environmentObject(self.observableSheet)
         .environmentObject(urlToOpen)
+        .accentColor(settings.accentColor)
+        .font(Font(.body, sizeModifier: CGFloat(settings.textSizeModifier)))
     }
 }
 

--- a/claw/ContentView.swift
+++ b/claw/ContentView.swift
@@ -86,8 +86,8 @@ struct ContentView: View {
 
     @Environment(\.sizeCategory) var sizeCategory
         
-    @ObservedObject var observableSheet = ObservableActiveSheet()
-    @ObservedObject var urlToOpen = ObservableURL()
+    @StateObject var observableSheet = ObservableActiveSheet()
+    @StateObject var urlToOpen = ObservableURL()
     
     var body: some View {
         let selection = Binding(get: { self._selection },
@@ -165,16 +165,16 @@ struct ContentView: View {
             switch item {
             case .story(let id):
                 EZPanel{
-                    StoryView(id)
-                }
+                    StoryView(id).id(id)
+                }.id(id)
                 .environmentObject(urlToOpen)
                 .environmentObject(settings)
                 .environmentObject(self.observableSheet)
                 .environment(\.managedObjectContext, viewContext)
             case .user(let username):
                 EZPanel{
-                    UserView(username)
-                }
+                    UserView(username).id(username)
+                }.id(username)
                 .environmentObject(urlToOpen)
                 .environmentObject(settings)
                 .environmentObject(self.observableSheet)

--- a/claw/ContentView.swift
+++ b/claw/ContentView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import CoreData
 import Combine
-import BetterSafariView
 
 struct DidReselectKey: EnvironmentKey {
     static let defaultValue = PassthroughSubject<TabSelection, Never>().eraseToAnyPublisher()

--- a/claw/ObservableURL.swift
+++ b/claw/ObservableURL.swift
@@ -3,12 +3,4 @@ import SwiftUI
 
 public class ObservableURL: ObservableObject {
     @Published var url: URL? = nil
-    
-    var bindingUrl: Binding<URL?> {
-        return Binding(get: {
-            return self.url
-        }, set: { newValue in
-            self.url = newValue
-        })
-    }
 }

--- a/claw/Settings/SettingsLinkView.swift
+++ b/claw/Settings/SettingsLinkView.swift
@@ -23,7 +23,7 @@ struct SettingsLinkView: View {
                 ZZLabel(iconBackgroundColor: iconColor, iconColor: .white, systemImage: systemImage, image: image, text: text)
         })
         // this is necessary until multiple sheets can be displayed at one time. See #22
-        .safariView(item: urlToOpen.bindingUrl, content: { url in
+            .safariView(item: $urlToOpen.url, content: { url in
             SafariView(
                 url: url,
                 configuration: SafariView.Configuration(

--- a/claw/Settings/SettingsLinkView.swift
+++ b/claw/Settings/SettingsLinkView.swift
@@ -23,7 +23,7 @@ struct SettingsLinkView: View {
                 ZZLabel(iconBackgroundColor: iconColor, iconColor: .white, systemImage: systemImage, image: image, text: text)
         })
         // this is necessary until multiple sheets can be displayed at one time. See #22
-        .fullScreenCover(item: urlToOpen.bindingUrl, content: { url in
+        .safariView(item: urlToOpen.bindingUrl, content: { url in
             SafariView(
                 url: url,
                 configuration: SafariView.Configuration(

--- a/claw/Stories/Story.swift
+++ b/claw/Stories/Story.swift
@@ -110,7 +110,9 @@ class StoryFetcher: ObservableObject {
             self.story = cachedStory
         }
         let url = URL(string: "https://lobste.rs/s/\(short_id).json")!
-            
+
+        self.session?.cancel()
+
         self.session = URLSession.shared.dataTask(with: url) {(data,response,error) in
             DispatchQueue.main.async {
                 self.isReloading = false

--- a/claw/Stories/Story.swift
+++ b/claw/Stories/Story.swift
@@ -12,6 +12,7 @@ struct Story: GenericStory, Codable, Hashable, Identifiable {
     var id: String {
         return short_id
     }
+
     var short_id: String
     var short_id_url: String
     var created_at: String
@@ -102,6 +103,13 @@ class StoryFetcher: ObservableObject {
     func reload() {
         self.session?.cancel()
         self.isReloading = true
+        self.load()
+    }
+    
+    func loadIfEmpty() {
+        if let _ = self.story {
+            return
+        }
         self.load()
     }
 

--- a/claw/Stories/Story.swift
+++ b/claw/Stories/Story.swift
@@ -86,9 +86,9 @@ struct Comment: Codable, Hashable, Identifiable {
 class StoryFetcher: ObservableObject {
     @Published var story: Story? = nil
 
-    var short_id: String
+    public var short_id: String? = nil
 
-    init(_ short_id: String) {
+    init(_ short_id: String? = nil) {
         self.short_id = short_id
     }
 
@@ -114,7 +114,10 @@ class StoryFetcher: ObservableObject {
     }
 
     func load() {
-        if let cachedStory = StoryFetcher.cachedStories.first(where: {$0.short_id == self.short_id}) {
+        guard let short_id = self.short_id else {
+            return
+        }
+        if let cachedStory = StoryFetcher.cachedStories.first(where: {$0.short_id == short_id}) {
             self.story = cachedStory
         }
         let url = URL(string: "https://lobste.rs/s/\(short_id).json")!
@@ -130,7 +133,7 @@ class StoryFetcher: ObservableObject {
                     let decodedLists = try JSONDecoder().decode(Story.self, from: d)
                     DispatchQueue.main.async {
                         self.story = decodedLists
-                        StoryFetcher.cachedStories.removeAll(where: {$0.short_id == self.short_id})
+                        StoryFetcher.cachedStories.removeAll(where: {$0.short_id == short_id})
                         StoryFetcher.cachedStories.append(decodedLists)
                         if StoryFetcher.cachedStories.count > 10 {
                             StoryFetcher.cachedStories.removeFirst()

--- a/claw/Stories/StoryListCellView.swift
+++ b/claw/Stories/StoryListCellView.swift
@@ -3,14 +3,6 @@ import SwiftUI
 
 public class ObservableActiveSheet: ObservableObject {
     @Published var sheet: ActiveSheet? = nil
-    
-    var bindingSheet: Binding<ActiveSheet?> {
-        return Binding(get: {
-            return self.sheet
-        }, set: { newValue in
-            self.sheet = newValue
-        })
-    }
 }
 
 struct StoryListCellView: View {

--- a/claw/Stories/StoryView.swift
+++ b/claw/Stories/StoryView.swift
@@ -50,7 +50,7 @@ struct StoryView: View {
     
     @EnvironmentObject var urlToOpen: ObservableURL
     @EnvironmentObject var observableSheet: ObservableActiveSheet
-    
+
     var body: some View {
         ScrollViewReader { scrollReader in
             
@@ -155,16 +155,19 @@ struct StoryView: View {
                     Image(systemName: "arrow.clockwise")
                 }
             }))
-        }
-        // this is necessary until multiple sheets can be displayed at one time. See #22
-        .fullScreenCover(item: urlToOpen.bindingUrl, content: { url in
+        } // scrollviewreader
+        .safariView(item: urlToOpen.bindingUrl,
+        content:
+         { url in
             SafariView(
                 url: url,
                 configuration: SafariView.Configuration(
                     entersReaderIfAvailable: settings.readerModeEnabled,
                     barCollapsingEnabled: true
                 )
-            ).preferredControlAccentColor(settings.accentColor).dismissButtonStyle(.close)
+            )
+            .preferredControlAccentColor(settings.accentColor)
+            .dismissButtonStyle(.close)
         })
     }
 }

--- a/claw/Stories/StoryView.swift
+++ b/claw/Stories/StoryView.swift
@@ -6,21 +6,19 @@ struct StoryView: View {
     var from_newest: NewestStory?
     @Environment(\.didReselect) var didReselect
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
-    @ObservedObject var story: StoryFetcher
+    @StateObject var story = StoryFetcher()
     
     init(_ short_id: String) {
         self.short_id = short_id
-        self.story = StoryFetcher(short_id)
     }
     
     init(_ story: NewestStory) {
         self.from_newest = story
         self.short_id = story.short_id
-        self.story = StoryFetcher(short_id)
     }
     
     var title: String {
-        if let story = story.story{
+        if let story = self.story.story{
             if story.comment_count == 1 {
                 return "1 comment"
             }
@@ -140,12 +138,13 @@ struct StoryView: View {
                     }
                 }
             }.onAppear(perform: {
+                self.story.short_id = self.short_id
                 self.story.load()
                 let contains = viewedItems.contains { element in
                     element.short_id == story.short_id && element.isStory
                 }
                 if !contains {
-                    viewContext.insert(ViewedItem(context: viewContext, short_id: story.short_id, isStory: true, isComment: false))
+                    viewContext.insert(ViewedItem(context: viewContext, short_id: story.short_id!, isStory: true, isComment: false))
                     try? viewContext.save()
                 }
             }).navigationBarItems(trailing: Button(action: {self.story.reload() }, label: {

--- a/claw/Stories/StoryView.swift
+++ b/claw/Stories/StoryView.swift
@@ -156,7 +156,7 @@ struct StoryView: View {
                 }
             }))
         } // scrollviewreader
-        .safariView(item: urlToOpen.bindingUrl,
+        .safariView(item: $urlToOpen.url,
         content:
          { url in
             SafariView(

--- a/claw/User/UserView.swift
+++ b/claw/User/UserView.swift
@@ -110,7 +110,7 @@ struct UserView: View {
             self.userFetcher.load()
         })
         // this is necessary until multiple sheets can be displayed at one time. See #22
-        .fullScreenCover(item: urlToOpen.bindingUrl, content: { url in
+        .safariView(item: urlToOpen.bindingUrl, content: { url in
             SafariView(
                 url: url,
                 configuration: SafariView.Configuration(

--- a/claw/User/UserView.swift
+++ b/claw/User/UserView.swift
@@ -110,7 +110,7 @@ struct UserView: View {
             self.userFetcher.load()
         })
         // this is necessary until multiple sheets can be displayed at one time. See #22
-        .safariView(item: urlToOpen.bindingUrl, content: { url in
+        .safariView(item: $urlToOpen.url, content: { url in
             SafariView(
                 url: url,
                 configuration: SafariView.Configuration(


### PR DESCRIPTION
Closes #44 

For some reason when you swipe to go back when the story is in a sheet (similar testing to #22 and #26) the story disappears. If you use the close button it doesn't. If I print the onDismiss that also get's called twice (sounds like something similar to https://github.com/stleamist/BetterSafariView/issues/15 although I don't know the fix). If I try to put SafariView on ContentView I get similar bugs to #26. This could be #21 but I don't understand why it would be fine for the close button but not swipe.

Other research for this ticket:
* https://github.com/samuelclay/NewsBlur/issues/769
* https://developer.apple.com/forums/thread/662510