### PR TITLE
Show submitted stories on user profiles

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -92,7 +92,7 @@ jobs:
           profile_story.description = ""
           profile_story.tags = [tag]
           profile_story.save!
-          4.times do |index|
+          12.times do |index|
             scroll_story = Story.find_or_initialize_by(
               title: "Claw UI Profile Scroll Fixture #{index + 1}"
             )

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -84,6 +84,14 @@ jobs:
             fixture.url = "https://example.com/claw-ui-vote-fixture"
             fixture.tags = [tag]
           end
+          profile_story = Story.find_or_initialize_by(
+            title: "Claw UI Profile Story Fixture"
+          )
+          profile_story.user = test_user
+          profile_story.url = "https://example.com/claw-ui-profile-story-fixture"
+          profile_story.description = ""
+          profile_story.tags = [tag]
+          profile_story.save!
           Vote.where(user: test_user, story: story, comment_id: nil).delete_all
           RUBY
 
@@ -97,6 +105,17 @@ jobs:
             exit 1
           fi
           echo "CLAW_UI_TEST_STORY_ID=$story_id" >> "$GITHUB_ENV"
+
+          profile_story_id="$(
+            docker compose run --rm -T app bin/rails runner \
+              'puts Story.find_by!(title: "Claw UI Profile Story Fixture").short_id' \
+              | tail -n 1
+          )"
+          if [[ ! "$profile_story_id" =~ ^[a-z0-9]+$ ]]; then
+            echo "Unable to determine the profile fixture short ID: $profile_story_id"
+            exit 1
+          fi
+          echo "CLAW_UI_TEST_PROFILE_STORY_ID=$profile_story_id" >> "$GITHUB_ENV"
 
       - name: Start Lobsters
         working-directory: ${{ env.LOBSTERS_DIRECTORY }}
@@ -181,6 +200,7 @@ jobs:
             -resultBundlePath results/ClawTests.xcresult \
             CLAW_UI_TEST_BASE_URL="$CLAW_UI_TEST_BASE_URL" \
             CLAW_UI_TEST_STORY_ID="$CLAW_UI_TEST_STORY_ID" \
+            CLAW_UI_TEST_PROFILE_STORY_ID="$CLAW_UI_TEST_PROFILE_STORY_ID" \
             test
 
       - name: Capture Lobsters diagnostics

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -92,6 +92,16 @@ jobs:
           profile_story.description = ""
           profile_story.tags = [tag]
           profile_story.save!
+          4.times do |index|
+            scroll_story = Story.find_or_initialize_by(
+              title: "Claw UI Profile Scroll Fixture #{index + 1}"
+            )
+            scroll_story.user = test_user
+            scroll_story.url = "https://example.com/claw-ui-profile-scroll-#{index + 1}"
+            scroll_story.description = ""
+            scroll_story.tags = [tag]
+            scroll_story.save!
+          end
           Vote.where(user: test_user, story: story, comment_id: nil).delete_all
           RUBY
 

--- a/claw.xcodeproj/xcshareddata/xcschemes/claw.xcscheme
+++ b/claw.xcodeproj/xcshareddata/xcschemes/claw.xcscheme
@@ -92,6 +92,11 @@
             value = "$(CLAW_UI_TEST_STORY_ID)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "CLAW_UI_TEST_PROFILE_STORY_ID"
+            value = "$(CLAW_UI_TEST_PROFILE_STORY_ID)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/claw/Stories/APIConfiguration.swift
+++ b/claw/Stories/APIConfiguration.swift
@@ -143,6 +143,13 @@ final class APIConfiguration: Sendable {
         }
         return url(path: "/t/\(tagPath)/page/\(page)")
     }
+
+    func userStoriesURL(username: String, page: Int) -> URL {
+        if page <= 1 {
+            return url(path: "/~\(username)/stories.json")
+        }
+        return url(path: "/~\(username)/stories/page/\(page).json")
+    }
     
     func storyURL(shortId: String) -> URL {
         url(path: "/s/\(shortId)")

--- a/claw/Stories/StoryListCellView.swift
+++ b/claw/Stories/StoryListCellView.swift
@@ -22,7 +22,6 @@ struct StoryListCellView: View {
             isActive: $navigationLinkActive,
             label: { EmptyView() })
             StoryCell(story: story)
-                .accessibilityIdentifier("story-row-\(story.short_id)")
                 .padding([.horizontal]).padding([.vertical], settings.layout > .compact ? 8.0 : 4.0).background(backgroundColorState.ignoresSafeArea()).contextMenu(menuItems:{
             if story.url.isEmpty {
                 Button(action: {
@@ -62,7 +61,9 @@ struct StoryListCellView: View {
                 Text("\(activeSheet.debugDescription)")
             }
         }
-        }.onTapGesture(count: 1, perform: {
+        }
+        .accessibilityIdentifier("story-row-\(story.short_id)")
+        .onTapGesture(count: 1, perform: {
             withAnimation(.easeIn) {
                 backgroundColorState = Color(UIColor.systemGray4)
                 withAnimation(.easeOut) {

--- a/claw/User/UserAvatarLoader.swift
+++ b/claw/User/UserAvatarLoader.swift
@@ -5,9 +5,11 @@ import SwiftUI
 struct UserAvatarLoader: View {
     var user: NewestUser
     var imageUrl: URL
+    var size: CGFloat
     
-    init(user: NewestUser) {
+    init(user: NewestUser, size: CGFloat = 100) {
         self.user = user
+        self.size = size
         
         if let url = APIConfiguration.shared.userAvatarURL(avatarPath: user.avatar_url) {
             self.imageUrl = url
@@ -25,11 +27,14 @@ struct UserAvatarLoader: View {
                 .imageScale(.large)
                 .redacted(reason: .placeholder)
         }
-        .frame(width: 100, height: 100, alignment: .center)
+        .frame(width: size, height: size, alignment: .center)
         .overlay(
-            Circle().stroke(Color(UIColor.separator), lineWidth: 3.0)
+            Circle().stroke(
+                Color(UIColor.separator),
+                lineWidth: max(1, size * 0.03)
+            )
         )
         .clipShape(Circle())
-        .shadow(radius: 5.0)
+        .shadow(radius: size * 0.05)
     }
 }

--- a/claw/User/UserStoryFetcher.swift
+++ b/claw/User/UserStoryFetcher.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+@MainActor
+final class UserStoryFetcher: GenericArrayFetcher<NewestStory> {
+    private static let storiesPerPage = 25
+
+    let username: String
+    private var canLoadMore = true
+
+    init(username: String) {
+        self.username = username
+    }
+
+    override func load() async throws {
+        guard !isLoading else {
+            return
+        }
+
+        let generation = captureContentGeneration()
+        hasAttemptedLoad = true
+        page = 1
+        canLoadMore = true
+        isLoading = true
+        defer {
+            if isCurrentContentGeneration(generation) {
+                isLoading = false
+            }
+        }
+
+        let stories: [NewestStory]
+        do {
+            stories = try await fetch(page: page)
+        } catch {
+            guard isCurrentContentGeneration(generation) else {
+                return
+            }
+            throw error
+        }
+        guard isCurrentContentGeneration(generation) else {
+            return
+        }
+        items = stories
+        canLoadMore = stories.count == Self.storiesPerPage
+        page += 1
+    }
+
+    override func more(_ story: NewestStory? = nil) async throws {
+        guard items.last == story, canLoadMore, !isLoadingMore else {
+            return
+        }
+
+        let generation = captureContentGeneration()
+        isLoadingMore = true
+        defer {
+            if isCurrentContentGeneration(generation) {
+                isLoadingMore = false
+            }
+        }
+
+        let stories: [NewestStory]
+        do {
+            stories = try await fetch(page: page)
+        } catch {
+            guard isCurrentContentGeneration(generation) else {
+                return
+            }
+            throw error
+        }
+        guard isCurrentContentGeneration(generation) else {
+            return
+        }
+        for story in stories where !items.contains(story) {
+            items.append(story)
+        }
+        canLoadMore = stories.count == Self.storiesPerPage
+        page += 1
+    }
+
+    private func fetch(page: Int) async throws -> [NewestStory] {
+        let url = APIConfiguration.shared.userStoriesURL(
+            username: username,
+            page: page
+        )
+        let data = try await LobstersPageLoader.shared.data(from: url)
+        return try JSONDecoder().decode([NewestStory].self, from: data)
+    }
+}

--- a/claw/User/UserView.swift
+++ b/claw/User/UserView.swift
@@ -298,31 +298,36 @@ private struct UserAvatarPortal: View {
 
     var body: some View {
         GeometryReader { geometry in
-            if let source = sourceAnchor.map({ geometry[$0] }),
-               let destinationFrame {
-                let globalFrame = geometry.frame(in: .global)
-                let destination = destinationFrame.offsetBy(
-                    dx: -globalFrame.minX,
-                    dy: -globalFrame.minY
-                )
-                let frame = interpolatedFrame(
-                    from: source,
-                    to: destination,
-                    progress: progress
-                )
-
-                UserAvatarLoader(user: user, size: frame.width)
-                    .position(x: frame.midX, y: frame.midY)
-                    .accessibilityIdentifier("user-profile-avatar")
-            } else if let sourceAnchor {
-                let frame = geometry[sourceAnchor]
-
+            if let frame = avatarFrame(in: geometry) {
                 UserAvatarLoader(user: user, size: frame.width)
                     .position(x: frame.midX, y: frame.midY)
                     .accessibilityIdentifier("user-profile-avatar")
             }
         }
         .allowsHitTesting(false)
+    }
+
+    private func avatarFrame(in geometry: GeometryProxy) -> CGRect? {
+        let source = sourceAnchor.map { geometry[$0] }
+        let destination = destinationFrame.map { frame in
+            let globalFrame = geometry.frame(in: .global)
+            return frame.offsetBy(
+                dx: -globalFrame.minX,
+                dy: -globalFrame.minY
+            )
+        }
+
+        if let source, let destination {
+            return interpolatedFrame(
+                from: source,
+                to: destination,
+                progress: progress
+            )
+        }
+
+        // LazyVStack eventually removes the source marker. Once collapsed,
+        // the toolbar destination must keep the shared avatar alive by itself.
+        return source ?? destination
     }
 
     private func interpolatedFrame(

--- a/claw/User/UserView.swift
+++ b/claw/User/UserView.swift
@@ -1,6 +1,17 @@
 import SwiftUI
 import BetterSafariView
 
+private struct UserAvatarSourcePreferenceKey: PreferenceKey {
+    static var defaultValue: Anchor<CGRect>?
+
+    static func reduce(
+        value: inout Anchor<CGRect>?,
+        nextValue: () -> Anchor<CGRect>?
+    ) {
+        value = nextValue() ?? value
+    }
+}
+
 struct UserView: View {
     @State var user: NewestUser?
     @StateObject private var userFetcher: UserFetcher
@@ -10,6 +21,7 @@ struct UserView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var error: Error?
     @State private var avatarCollapseProgress: CGFloat = 0
+    @State private var titleAvatarFrame: CGRect?
     
     @Environment(Settings.self) var settings
     @EnvironmentObject var urlToOpen: ObservableURL
@@ -37,15 +49,21 @@ struct UserView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 if let user = self.user {
-                    UserAvatarLoader(
-                        user: user,
-                        size: Layout.profileAvatarSize
-                    )
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical)
-                        .opacity(1 - avatarCollapseProgress)
-                        .scaleEffect(1 - (0.15 * avatarCollapseProgress))
-                        .accessibilityIdentifier("user-profile-avatar")
+                    HStack {
+                        Spacer()
+                        Color.clear
+                            .frame(
+                                width: Layout.profileAvatarSize,
+                                height: Layout.profileAvatarSize
+                            )
+                            .anchorPreference(
+                                key: UserAvatarSourcePreferenceKey.self,
+                                value: .bounds
+                            ) { $0 }
+                            .accessibilityHidden(true)
+                        Spacer()
+                    }
+                    .padding(.vertical)
 
                     if let karma = user.karma {
                         HStack {
@@ -189,28 +207,38 @@ struct UserView: View {
         }
         .navigationBarTitle(self.username ?? "")
         .toolbar {
-            if let user = self.user, avatarCollapseProgress > 0 {
+            if self.user != nil {
                 ToolbarItem(placement: .principal) {
                     HStack(
                         spacing: Layout.titleAvatarSpacing * avatarCollapseProgress
                     ) {
-                        UserAvatarLoader(
-                            user: user,
-                            size: Layout.titleAvatarSize
-                        )
-                        .frame(
-                            width: Layout.titleAvatarSize * avatarCollapseProgress,
-                            height: Layout.titleAvatarSize
-                        )
-                        .scaleEffect(avatarCollapseProgress)
-                        .opacity(avatarCollapseProgress)
-                        .accessibilityIdentifier("user-title-avatar")
-                        .accessibilityHidden(avatarCollapseProgress < 0.9)
+                        Color.clear
+                            .frame(
+                                width: Layout.titleAvatarSize,
+                                height: Layout.titleAvatarSize
+                            )
+                            .onGeometryChange(for: CGRect.self) { geometry in
+                                geometry.frame(in: .global)
+                            } action: { frame in
+                                titleAvatarFrame = frame
+                            }
+                            .frame(width: Layout.titleAvatarSize * avatarCollapseProgress)
+                            .accessibilityHidden(true)
 
                         Text(self.username ?? "")
                             .font(style: .headline)
                     }
                 }
+            }
+        }
+        .overlayPreferenceValue(UserAvatarSourcePreferenceKey.self) { sourceAnchor in
+            if let user = self.user {
+                UserAvatarPortal(
+                    user: user,
+                    sourceAnchor: sourceAnchor,
+                    destinationFrame: titleAvatarFrame,
+                    progress: avatarCollapseProgress
+                )
             }
         }
         .onReceive(didReselect) { _ in
@@ -259,6 +287,57 @@ struct UserView: View {
                 )
             ).preferredControlAccentColor(settings.accentColor).dismissButtonStyle(.close)
         })
+    }
+}
+
+private struct UserAvatarPortal: View {
+    let user: NewestUser
+    let sourceAnchor: Anchor<CGRect>?
+    let destinationFrame: CGRect?
+    let progress: CGFloat
+
+    var body: some View {
+        GeometryReader { geometry in
+            if let source = sourceAnchor.map({ geometry[$0] }),
+               let destinationFrame {
+                let globalFrame = geometry.frame(in: .global)
+                let destination = destinationFrame.offsetBy(
+                    dx: -globalFrame.minX,
+                    dy: -globalFrame.minY
+                )
+                let frame = interpolatedFrame(
+                    from: source,
+                    to: destination,
+                    progress: progress
+                )
+
+                UserAvatarLoader(user: user, size: frame.width)
+                    .position(x: frame.midX, y: frame.midY)
+                    .accessibilityIdentifier("user-profile-avatar")
+            } else if let sourceAnchor {
+                let frame = geometry[sourceAnchor]
+
+                UserAvatarLoader(user: user, size: frame.width)
+                    .position(x: frame.midX, y: frame.midY)
+                    .accessibilityIdentifier("user-profile-avatar")
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func interpolatedFrame(
+        from source: CGRect,
+        to destination: CGRect,
+        progress: CGFloat
+    ) -> CGRect {
+        let progress = min(max(progress, 0), 1)
+
+        return CGRect(
+            x: source.minX + ((destination.minX - source.minX) * progress),
+            y: source.minY + ((destination.minY - source.minY) * progress),
+            width: source.width + ((destination.width - source.width) * progress),
+            height: source.height + ((destination.height - source.height) * progress)
+        )
     }
 }
 

--- a/claw/User/UserView.swift
+++ b/claw/User/UserView.swift
@@ -3,23 +3,27 @@ import BetterSafariView
 
 struct UserView: View {
     @State var user: NewestUser?
-    @ObservedObject var userFetcher: UserFetcher
+    @StateObject private var userFetcher: UserFetcher
+    @StateObject private var stories: UserStoryFetcher
     var username: String?
     @Environment(\.didReselect) var didReselect
     @Environment(\.dismiss) private var dismiss
+    @State private var error: Error?
     
     @Environment(Settings.self) var settings
     @EnvironmentObject var urlToOpen: ObservableURL
     
     init(_ user: NewestUser) {
-        self.userFetcher = UserFetcher(self.username ?? "")
+        self._userFetcher = StateObject(wrappedValue: UserFetcher(user.username))
+        self._stories = StateObject(wrappedValue: UserStoryFetcher(username: user.username))
         self.user = user
         self.username = user.username
     }
     
     init(_ username: String) {
         self.username = username
-        self.userFetcher = UserFetcher(username)
+        self._userFetcher = StateObject(wrappedValue: UserFetcher(username))
+        self._stories = StateObject(wrappedValue: UserStoryFetcher(username: username))
     }
     
     var body: some View {
@@ -100,8 +104,42 @@ struct UserView: View {
                     }
                 }
             }
+            Section("Stories") {
+                if stories.items.isEmpty && (!stories.hasAttemptedLoad || stories.isLoading) {
+                    ForEach(0..<3) { _ in
+                        StoryListCellView(story: NewestStory.placeholder)
+                            .redacted(reason: .placeholder)
+                            .allowsHitTesting(false)
+                    }
+                } else if stories.items.isEmpty {
+                    Label("No submitted stories", systemImage: "newspaper")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(stories.items) { story in
+                        StoryListCellView(story: story)
+                            .task {
+                                do {
+                                    try await stories.more(story)
+                                } catch is CancellationError {
+                                    return
+                                } catch {
+                                    self.error = error
+                                }
+                            }
+                    }
+                }
+
+                if stories.isLoadingMore {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                }
+            }
         }
-        .navigationBarTitle(self.username ?? "").onReceive(didReselect) { _ in
+        .navigationBarTitle(self.username ?? "")
+        .onReceive(didReselect) { _ in
             DispatchQueue.main.async {
                 dismiss()
             }
@@ -112,11 +150,31 @@ struct UserView: View {
                     return
                 }
                 self.user = try await self.userFetcher.load()
+            } catch is CancellationError {
+                return
             } catch {
-                // todo: handle error
-                print(error)
+                self.error = error
             }
         }
+        .task {
+            do {
+                try await stories.loadIfEmpty()
+            } catch is CancellationError {
+                return
+            } catch {
+                self.error = error
+            }
+        }
+        .refreshable {
+            do {
+                try await stories.reload()
+            } catch is CancellationError {
+                return
+            } catch {
+                self.error = error
+            }
+        }
+        .errorAlert(error: $error)
         // this is necessary until multiple sheets can be displayed at one time. See #22
         .safariView(item: $urlToOpen.url, content: { url in
             SafariView(

--- a/claw/User/UserView.swift
+++ b/claw/User/UserView.swift
@@ -20,7 +20,8 @@ struct UserView: View {
     @Environment(\.didReselect) var didReselect
     @Environment(\.dismiss) private var dismiss
     @State private var error: Error?
-    @State private var avatarCollapseProgress: CGFloat = 0
+    @State private var avatarScrollOffset: CGFloat = 0
+    @State private var initialAvatarFrame: CGRect?
     @State private var titleAvatarFrame: CGRect?
     
     @Environment(Settings.self) var settings
@@ -56,6 +57,14 @@ struct UserView: View {
                                 width: Layout.profileAvatarSize,
                                 height: Layout.profileAvatarSize
                             )
+                            .onGeometryChange(for: CGRect.self) { geometry in
+                                geometry.frame(in: .global)
+                            } action: { frame in
+                                guard avatarScrollOffset <= 0 else {
+                                    return
+                                }
+                                initialAvatarFrame = frame
+                            }
                             .anchorPreference(
                                 key: UserAvatarSourcePreferenceKey.self,
                                 value: .bounds
@@ -198,12 +207,9 @@ struct UserView: View {
             }
         }
         .onScrollGeometryChange(for: CGFloat.self, of: { geometry in
-            let offset = geometry.contentOffset.y + geometry.contentInsets.top
-            let collapseDistance = Layout.profileAvatarSize
-                - (2 * Layout.titleAvatarSize)
-            return min(max(offset / collapseDistance, 0), 1)
-        }) { _, progress in
-            avatarCollapseProgress = progress
+            geometry.contentOffset.y + geometry.contentInsets.top
+        }) { _, offset in
+            avatarScrollOffset = offset
         }
         .navigationBarTitle(self.username ?? "")
         .toolbar {
@@ -287,6 +293,18 @@ struct UserView: View {
                 )
             ).preferredControlAccentColor(settings.accentColor).dismissButtonStyle(.close)
         })
+    }
+
+    private var avatarCollapseProgress: CGFloat {
+        guard let initialAvatarFrame, let titleAvatarFrame else {
+            return 0
+        }
+
+        let collapseDistance = max(
+            initialAvatarFrame.midY - titleAvatarFrame.midY,
+            1
+        )
+        return min(max(avatarScrollOffset / collapseDistance, 0), 1)
     }
 }
 

--- a/claw/User/UserView.swift
+++ b/claw/User/UserView.swift
@@ -27,96 +27,122 @@ struct UserView: View {
     }
     
     var body: some View {
-        List {
-            if let user = self.user {
-                HStack(alignment: .center) {
-                    Spacer()
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if let user = self.user {
                     UserAvatarLoader(user: user)
-                    Spacer()
-                }
-                if let karma = user.karma {
-                    HStack {
-                        Text("Karma").bold()
-                        Text("\(karma)")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical)
+
+                    if let karma = user.karma {
+                        HStack {
+                            Text("Karma").bold()
+                            Text("\(karma)")
+                        }
+                        .padding()
+                        Divider().padding(.leading)
                     }
-                }
-                if let username = user.github_username, let url = URL(string: "https://github.com/" + username) {
-                    Button(action: {
-                        if settings.browser == .inAppSafari {
-                            urlToOpen.url = url
-                        } else {
-                            UIApplication.shared.open(url)
-                        }
-                    }, label: {
-                        HStack {
-                            Text("GitHub").bold()
-                            Text(username).foregroundColor(.accentColor)
-                        }
-                    })
-                }
-                if let username = user.twitter_username, let url = URL(string: "https://twitter.com/\(username)") {
-                    Button(action: {
-                        if settings.browser == .inAppSafari {
-                            urlToOpen.url = url
-                        } else {
-                            UIApplication.shared.open(url)
-                        }
-                    }, label: {
-                        HStack {
-                            Text("Twitter").bold()
-                            Text("@" + username).foregroundColor(.accentColor)
-                        }
-                    })
-                    
-                }
-                if let keybase = user.keybase_signatures {
-                    HStack {
-                        Text("Keybase").bold()
-                        VStack(alignment: .leading) {
-                            ForEach(keybase) { auth in
-                                HStack {
-                                    Text("@" + auth.kb_username).foregroundColor(.accentColor).onTapGesture(count: 1, perform: {
-                                        let keybase_url = URL(string: "https://keybase.io/" + auth.kb_username)!
-                                        if settings.browser == .inAppSafari {
-                                            urlToOpen.url = keybase_url
-                                        } else {
-                                            UIApplication.shared.open(keybase_url)
-                                        }
-                                    })
-                                    Text("\(Image(systemName: "checkmark.shield.fill"))").foregroundColor(.accentColor).onTapGesture(count: 1, perform: {
-                                        if let keybase_url = URL(string: "https://keybase.io/" + auth.kb_username  + "/sigchain#" + auth.sig_hash) {
+                    if let username = user.github_username, let url = URL(string: "https://github.com/" + username) {
+                        Button(action: {
+                            if settings.browser == .inAppSafari {
+                                urlToOpen.url = url
+                            } else {
+                                UIApplication.shared.open(url)
+                            }
+                        }, label: {
+                            HStack {
+                                Text("GitHub").bold()
+                                Text(username).foregroundColor(.accentColor)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
+                        })
+                        .buttonStyle(.plain)
+                        .padding()
+                        Divider().padding(.leading)
+                    }
+                    if let username = user.twitter_username, let url = URL(string: "https://twitter.com/\(username)") {
+                        Button(action: {
+                            if settings.browser == .inAppSafari {
+                                urlToOpen.url = url
+                            } else {
+                                UIApplication.shared.open(url)
+                            }
+                        }, label: {
+                            HStack {
+                                Text("Twitter").bold()
+                                Text("@" + username).foregroundColor(.accentColor)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
+                        })
+                        .buttonStyle(.plain)
+                        .padding()
+                        Divider().padding(.leading)
+                    }
+                    if let keybase = user.keybase_signatures {
+                        HStack(alignment: .top) {
+                            Text("Keybase").bold()
+                            VStack(alignment: .leading) {
+                                ForEach(keybase) { auth in
+                                    HStack {
+                                        Text("@" + auth.kb_username).foregroundColor(.accentColor).onTapGesture(count: 1, perform: {
+                                            let keybase_url = URL(string: "https://keybase.io/" + auth.kb_username)!
                                             if settings.browser == .inAppSafari {
                                                 urlToOpen.url = keybase_url
                                             } else {
                                                 UIApplication.shared.open(keybase_url)
                                             }
-                                        }
-                                    })
+                                        })
+                                        Text("\(Image(systemName: "checkmark.shield.fill"))").foregroundColor(.accentColor).onTapGesture(count: 1, perform: {
+                                            if let keybase_url = URL(string: "https://keybase.io/" + auth.kb_username  + "/sigchain#" + auth.sig_hash) {
+                                                if settings.browser == .inAppSafari {
+                                                    urlToOpen.url = keybase_url
+                                                } else {
+                                                    UIApplication.shared.open(keybase_url)
+                                                }
+                                            }
+                                        })
+                                    }
                                 }
                             }
                         }
+                        .padding()
+                        Divider().padding(.leading)
+                    }
+                    if !user.about.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("About").bold()
+                            HTMLView(html: user.about.trimmingCharacters(in: .whitespacesAndNewlines))
+                        }
+                        .padding()
                     }
                 }
-                if !user.about.isEmpty {
-                    VStack(alignment: .leading) {
-                        Text("About").bold()
-                        HTMLView(html: user.about.trimmingCharacters(in: .whitespacesAndNewlines))
-                    }
-                }
-            }
-            Section("Stories") {
+
+                Text("Stories")
+                    .font(style: .title2)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal)
+                    .padding(.top, 24)
+                    .padding(.bottom, 8)
+                Divider().padding(.leading)
+
                 if stories.items.isEmpty && (!stories.hasAttemptedLoad || stories.isLoading) {
                     ForEach(0..<3) { _ in
                         StoryListCellView(story: NewestStory.placeholder)
                             .redacted(reason: .placeholder)
                             .allowsHitTesting(false)
+                        Divider().padding(.leading)
                     }
                 } else if stories.items.isEmpty {
                     Label("No submitted stories", systemImage: "newspaper")
                         .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding()
                 } else {
                     ForEach(stories.items) { story in
                         StoryListCellView(story: story)
+                            .id(story)
                             .task {
                                 do {
                                     try await stories.more(story)
@@ -126,6 +152,7 @@ struct UserView: View {
                                     self.error = error
                                 }
                             }
+                        Divider().padding(.leading)
                     }
                 }
 
@@ -135,6 +162,7 @@ struct UserView: View {
                         ProgressView()
                         Spacer()
                     }
+                    .padding()
                 }
             }
         }

--- a/claw/User/UserView.swift
+++ b/claw/User/UserView.swift
@@ -9,9 +9,16 @@ struct UserView: View {
     @Environment(\.didReselect) var didReselect
     @Environment(\.dismiss) private var dismiss
     @State private var error: Error?
+    @State private var avatarCollapseProgress: CGFloat = 0
     
     @Environment(Settings.self) var settings
     @EnvironmentObject var urlToOpen: ObservableURL
+
+    private enum Layout {
+        static let profileAvatarSize: CGFloat = 100
+        static let titleAvatarSize: CGFloat = 28
+        static let titleAvatarSpacing: CGFloat = 8
+    }
     
     init(_ user: NewestUser) {
         self._userFetcher = StateObject(wrappedValue: UserFetcher(user.username))
@@ -30,9 +37,15 @@ struct UserView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 if let user = self.user {
-                    UserAvatarLoader(user: user)
+                    UserAvatarLoader(
+                        user: user,
+                        size: Layout.profileAvatarSize
+                    )
                         .frame(maxWidth: .infinity)
                         .padding(.vertical)
+                        .opacity(1 - avatarCollapseProgress)
+                        .scaleEffect(1 - (0.15 * avatarCollapseProgress))
+                        .accessibilityIdentifier("user-profile-avatar")
 
                     if let karma = user.karma {
                         HStack {
@@ -166,7 +179,40 @@ struct UserView: View {
                 }
             }
         }
+        .onScrollGeometryChange(for: CGFloat.self, of: { geometry in
+            let offset = geometry.contentOffset.y + geometry.contentInsets.top
+            let collapseDistance = Layout.profileAvatarSize
+                - (2 * Layout.titleAvatarSize)
+            return min(max(offset / collapseDistance, 0), 1)
+        }) { _, progress in
+            avatarCollapseProgress = progress
+        }
         .navigationBarTitle(self.username ?? "")
+        .toolbar {
+            if let user = self.user, avatarCollapseProgress > 0 {
+                ToolbarItem(placement: .principal) {
+                    HStack(
+                        spacing: Layout.titleAvatarSpacing * avatarCollapseProgress
+                    ) {
+                        UserAvatarLoader(
+                            user: user,
+                            size: Layout.titleAvatarSize
+                        )
+                        .frame(
+                            width: Layout.titleAvatarSize * avatarCollapseProgress,
+                            height: Layout.titleAvatarSize
+                        )
+                        .scaleEffect(avatarCollapseProgress)
+                        .opacity(avatarCollapseProgress)
+                        .accessibilityIdentifier("user-title-avatar")
+                        .accessibilityHidden(avatarCollapseProgress < 0.9)
+
+                        Text(self.username ?? "")
+                            .font(style: .headline)
+                    }
+                }
+            }
+        }
         .onReceive(didReselect) { _ in
             DispatchQueue.main.async {
                 dismiss()

--- a/clawTests/clawTests.swift
+++ b/clawTests/clawTests.swift
@@ -41,6 +41,23 @@ class clawTests: XCTestCase {
         XCTAssertEqual(TabBarMinimizePreference.onScroll.behavior, .onScrollDown)
     }
 
+    func testUserStoriesURLsUseTheUserFeedAndPaginationRoutes() {
+        XCTAssertEqual(
+            APIConfiguration.shared.userStoriesURL(
+                username: "alice",
+                page: 1
+            ).path,
+            "/~alice/stories.json"
+        )
+        XCTAssertEqual(
+            APIConfiguration.shared.userStoriesURL(
+                username: "alice",
+                page: 2
+            ).path,
+            "/~alice/stories/page/2.json"
+        )
+    }
+
     func testStoryHTMLParserParsesNestedComments() throws {
         let html = """
         <html>

--- a/clawUITests/clawUITests.swift
+++ b/clawUITests/clawUITests.swift
@@ -11,6 +11,7 @@ class clawUITests: XCTestCase {
 
     private let storyVotePrefix = "story-vote-"
     private let voteFixtureTitle = "Claw UI Vote Fixture"
+    private let profileFixtureTitle = "Claw UI Profile Story Fixture"
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -95,7 +96,7 @@ class clawUITests: XCTestCase {
         XCTAssertEqual(storyTitle.label, voteFixtureTitle)
     }
 
-    func testSignedInUsernameOpensProfile() throws {
+    func testSignedInProfileShowsSubmittedStoryAndOpensIt() throws {
         let app = configuredApplication()
         app.launch()
 
@@ -112,6 +113,29 @@ class clawUITests: XCTestCase {
             app.navigationBars["test"].waitForExistence(timeout: 10),
             "Tapping the signed-in username did not open its profile."
         )
+
+        let storyID = try localProfileStoryID()
+        let storyIdentifier = "story-row-\(storyID)"
+        let profileStory = app.staticTexts
+            .matching(identifier: storyIdentifier)
+            .matching(NSPredicate(format: "label == %@", profileFixtureTitle))
+            .firstMatch
+        scroll(app.collectionViews.firstMatch, untilHittable: profileStory)
+        XCTAssertTrue(
+            profileStory.isHittable,
+            "The signed-in user's submitted story was not visible."
+        )
+        profileStory.tap()
+
+        let loadedStory = app.descendants(matching: .any)[
+            "story-title-\(storyID)"
+        ]
+        XCTAssertTrue(
+            loadedStory.waitForExistence(timeout: 20),
+            "Tapping the profile story did not load its local story page."
+        )
+        XCTAssertEqual(loadedStory.label, profileFixtureTitle)
+        XCTAssertTrue(app.navigationBars.buttons["test"].exists)
     }
 
     func testLaunchPerformance() throws {
@@ -229,6 +253,20 @@ class clawUITests: XCTestCase {
         return storyID
     }
 
+    private func localProfileStoryID() throws -> String {
+        let storyID = try XCTUnwrap(
+            ProcessInfo.processInfo.environment[
+                "CLAW_UI_TEST_PROFILE_STORY_ID"
+            ]
+        )
+        XCTAssertFalse(storyID.isEmpty)
+        XCTAssertFalse(
+            storyID.contains("/"),
+            "The profile story fixture must be a Lobsters short ID."
+        )
+        return storyID
+    }
+
     private func waitForLabel(
         _ label: String,
         on element: XCUIElement,
@@ -243,5 +281,14 @@ class clawUITests: XCTestCase {
             .completed,
             "Expected \(element.identifier) to become “\(label)”."
         )
+    }
+
+    private func scroll(
+        _ container: XCUIElement,
+        untilHittable element: XCUIElement
+    ) {
+        for _ in 0..<8 where !element.isHittable {
+            container.swipeUp()
+        }
     }
 }

--- a/clawUITests/clawUITests.swift
+++ b/clawUITests/clawUITests.swift
@@ -123,15 +123,29 @@ class clawUITests: XCTestCase {
 
         let profileScrollView = app.scrollViews.firstMatch
         XCTAssertTrue(profileScrollView.waitForExistence(timeout: 5))
+        let profileAvatar = app.descendants(matching: .any)[
+            "user-profile-avatar"
+        ]
+        XCTAssertTrue(
+            profileAvatar.waitForExistence(timeout: 5),
+            "The user's profile avatar was not visible."
+        )
         profileScrollView.swipeUp()
         profileScrollView.swipeUp()
 
-        let titleAvatar = app.descendants(matching: .any)[
-            "user-title-avatar"
-        ]
         XCTAssertTrue(
-            titleAvatar.waitForExistence(timeout: 5),
+            profileAvatar.waitForExistence(timeout: 5),
             "The user's avatar did not move into the title after scrolling."
+        )
+        XCTAssertLessThan(
+            profileAvatar.frame.width,
+            50,
+            "The profile avatar did not shrink to its title size."
+        )
+        XCTAssertLessThan(
+            profileAvatar.frame.midY,
+            120,
+            "The same profile avatar did not move into the navigation title."
         )
 
         scroll(profileScrollView, untilHittable: profileStory)

--- a/clawUITests/clawUITests.swift
+++ b/clawUITests/clawUITests.swift
@@ -120,7 +120,21 @@ class clawUITests: XCTestCase {
             .matching(identifier: storyIdentifier)
             .matching(NSPredicate(format: "label == %@", profileFixtureTitle))
             .firstMatch
-        scroll(app.collectionViews.firstMatch, untilHittable: profileStory)
+
+        let profileScrollView = app.scrollViews.firstMatch
+        XCTAssertTrue(profileScrollView.waitForExistence(timeout: 5))
+        profileScrollView.swipeUp()
+        profileScrollView.swipeUp()
+
+        let titleAvatar = app.descendants(matching: .any)[
+            "user-title-avatar"
+        ]
+        XCTAssertTrue(
+            titleAvatar.waitForExistence(timeout: 5),
+            "The user's avatar did not move into the title after scrolling."
+        )
+
+        scroll(profileScrollView, untilHittable: profileStory)
         XCTAssertTrue(
             profileStory.isHittable,
             "The signed-in user's submitted story was not visible."

--- a/clawUITests/clawUITests.swift
+++ b/clawUITests/clawUITests.swift
@@ -153,6 +153,15 @@ class clawUITests: XCTestCase {
             profileStory.isHittable,
             "The signed-in user's submitted story was not visible."
         )
+        XCTAssertTrue(
+            profileAvatar.waitForExistence(timeout: 5),
+            "The title avatar disappeared after its profile row was recycled."
+        )
+        XCTAssertLessThan(
+            profileAvatar.frame.midY,
+            120,
+            "The title avatar left the navigation title after prolonged scrolling."
+        )
         profileStory.tap()
 
         let loadedStory = app.descendants(matching: .any)[

--- a/clawUITests/clawUITests.swift
+++ b/clawUITests/clawUITests.swift
@@ -130,6 +130,25 @@ class clawUITests: XCTestCase {
             profileAvatar.waitForExistence(timeout: 5),
             "The user's profile avatar was not visible."
         )
+        let expandedAvatarWidth = profileAvatar.frame.width
+        let dragStart = profileScrollView.coordinate(
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)
+        )
+        dragStart.press(
+            forDuration: 0.1,
+            thenDragTo: dragStart.withOffset(CGVector(dx: 0, dy: -30))
+        )
+
+        XCTAssertLessThan(
+            profileAvatar.frame.width,
+            expandedAvatarWidth,
+            "The profile avatar did not begin shrinking after a short scroll."
+        )
+        XCTAssertGreaterThan(
+            profileAvatar.frame.width,
+            50,
+            "The profile avatar reached its title size too early."
+        )
         profileScrollView.swipeUp()
         profileScrollView.swipeUp()
 


### PR DESCRIPTION
Closes #2.

## Summary
- Load and display submitted stories on user profiles with pagination, pull-to-refresh, loading, empty, and error states.
- Render the profile in a `ScrollView` and `LazyVStack` so submitted stories reuse the same full-width story cells as the main feeds without nested `List` styling.
- Render one avatar in a portal-style overlay that interpolates between anchored profile and navigation-title frames as the profile scrolls.
- Pace the avatar transition over its measured vertical travel distance so it remains in the profile header longer and arrives naturally in the title.
- Keep the collapsed avatar rendered from the toolbar destination after `LazyVStack` recycles its source marker.
- Keep profile story rows directly navigable to the real story detail.
- Add deterministic local Docker fixtures authored by the test account, including enough stories to exercise lazy-view recycling.
- Expand the signed-in UI test through partial avatar collapse, source recycling, shared-avatar persistence, submitted story, and story detail.

## Root cause
The original transition divided scroll offset by a fixed 44-point distance, so the avatar reached the navigation title while most of its profile row was still visible. The progress range now comes from the measured distance between the avatar’s initial center and its title center.

The portal also previously required the avatar anchor contributed by the profile row. Once prolonged scrolling caused `LazyVStack` to remove that offscreen row, the preference became nil and the portal stopped rendering—even though its navigation-title destination still existed. The destination frame now keeps the same portal element alive in its collapsed state.

## Testing
- Debug app build succeeded for iOS Simulator.
- All 37 unit tests passed against an isolated Lobsters Docker instance on loopback.
- The focused UI test passed: local login → signed-in profile → controlled short drag leaves the avatar at an intermediate size → full collapse → source recycling → avatar remains in title → submitted story → story detail.
- RocketSim screenshots remained available, but its accessibility/interaction bridge returned no actionable elements on this simulator, so no new visual-interaction claim is based on that tool.
